### PR TITLE
Add checks to avoid running the source machinery if 0 events is reque…

### DIFF
--- a/laidbax/XENONSource.py
+++ b/laidbax/XENONSource.py
@@ -34,6 +34,8 @@ class XENONSource(MonteCarloSource):
         """Simulate n_events from this source."""
         n_events = int(n_events)
         c = self.config
+        if n_events==0:
+            return simulate_signals(c,[],[],None)
 
         energies = self.energy_distribution.get_random(n_events)
 

--- a/laidbax/signals.py
+++ b/laidbax/signals.py
@@ -41,6 +41,7 @@ def simulate_signals(config, n_photons, n_electrons, energies=None):
         ('cs1', np.float),
         ('cs2', np.float),
     ])
+    #if n = 0, do not procede:
 
     if energies is not None:
         d['energy'] = energies


### PR DESCRIPTION
If a source simulates zero events, the simulation proceeds instead of short-circuiting. 
Adds a simple short-circuit. 